### PR TITLE
Install pangeo-forge-recipes from branch `@prefect-retry`

### DIFF
--- a/feedstock/meta.yaml
+++ b/feedstock/meta.yaml
@@ -1,6 +1,6 @@
 title: "NOAA Coastwatch Geo-Polar SST"
 description: "NOAA Geo-Polar Blended Global Sea Surface Temperature Analysis (Level 4)"
-pangeo_forge_version: "0.8.2"
+pangeo_forge_version: "@prefect-retry"
 pangeo_notebook_version: "2021.12.02"
 recipes:
   - id: noaa-coastwatch-geopolar-sst


### PR DESCRIPTION
This PR directs Pangeo Forge Cloud (specifically, the Registrar) to install `pangeo-forge-recipes` from the `@prefect-retry` branch on GitHub, which has the following diff with the default branch:

> https://github.com/pangeo-forge/pangeo-forge-recipes/compare/master..prefect-retry

The purpose of this branch is to see if using retries will resolve the timeout errors we saw on the first production run of this feedstock. To support installing from GitHub branches, I've also pushed https://github.com/pangeo-forge/registrar/pull/26 to Docker Hub.

xref https://github.com/pangeo-forge/noaa-coastwatch-geopolar-sst-feedstock/issues/2#issuecomment-1102950710