### PR TITLE
Increase chunk size to reduce task graph size

### DIFF
--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -38,6 +38,6 @@ pattern = FilePattern(make_url, time_concat_dim)
 
 recipe = XarrayZarrRecipe(
     pattern,
-    inputs_per_chunk=2,
-    target_chunks={'time': 2, 'lat': 1800, 'lon': 7200},
+    inputs_per_chunk=4,
+    target_chunks={'time': 4, 'lat': 1800, 'lon': 7200},
     )


### PR DESCRIPTION
This PR implements the graph size limitation workaround idea proposed in https://github.com/pangeo-forge/noaa-coastwatch-geopolar-sst-feedstock/issues/2#issuecomment-1106677244.